### PR TITLE
I2C_idle counter logic was forcing it to always idle regardless of registers

### DIFF
--- a/I2C_HardwareDrvr.c
+++ b/I2C_HardwareDrvr.c
@@ -147,8 +147,8 @@ return count;
 static void I2C_Idle(void) {                                                     //- Supporting Function
     UINT8 t = 255;
     /* Wait until I2C Bus is Inactive */
-    while (I2CCONbits.SEN || I2CCONbits.PEN || I2CCONbits.RCEN ||
-            I2CCONbits.RSEN || I2CCONbits.ACKEN || I2CSTATbits.TRSTAT || t--);
+    while ((I2CCONbits.SEN || I2CCONbits.PEN || I2CCONbits.RCEN ||
+            I2CCONbits.RSEN || I2CCONbits.ACKEN || I2CSTATbits.TRSTAT) && !t-- );
 }
 
 static BOOL I2C_Start(void) {                                                    //- Supporting Function


### PR DESCRIPTION
using t-- means always count 255 times regardless of the status registers and their status also only matters on the 1 -> 0 transition. If any flag is not ready then it will wrap 0 -> 255 and the flags will all be ignored again until the next 1 -> 0 transition.
